### PR TITLE
Benchmark improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -899,6 +899,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "diesel"
+version = "2.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62c6fcf842f17f8c78ecf7c81d75c5ce84436b41ee07e03f490fbb5f5a8731d8"
+dependencies = [
+ "bitflags 2.4.1",
+ "byteorder",
+ "diesel_derives",
+ "itoa",
+]
+
+[[package]]
+name = "diesel-async"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acada1517534c92d3f382217b485db8a8638f111b0e3f2a2a8e26165050f77be"
+dependencies = [
+ "async-trait",
+ "diesel",
+ "futures-util",
+ "scoped-futures",
+ "tokio",
+ "tokio-postgres",
+]
+
+[[package]]
+name = "diesel_derives"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8337737574f55a468005a83499da720f20c65586241ffea339db9ecdfd2b44"
+dependencies = [
+ "diesel_table_macro_syntax",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.41",
+]
+
+[[package]]
+name = "diesel_table_macro_syntax"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc5557efc453706fed5e4fa85006fe9817c224c3f480a34c7e5959fd700921c5"
+dependencies = [
+ "syn 2.0.41",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2787,6 +2834,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
 
 [[package]]
+name = "scoped-futures"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1473e24c637950c9bd38763220bea91ec3e095a89f672bbd7a10d03e77ba467"
+dependencies = [
+ "cfg-if",
+ "pin-utils",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4055,6 +4112,8 @@ dependencies = [
 name = "wtx-bench"
 version = "0.0.1"
 dependencies = [
+ "diesel",
+ "diesel-async",
  "futures",
  "plotters",
  "sqlx",

--- a/wtx-bench/Cargo.toml
+++ b/wtx-bench/Cargo.toml
@@ -4,6 +4,8 @@ plotters = { default-features = false, features = ["histogram", "svg_backend"], 
 sqlx = { default-features = false, features = ["postgres", "runtime-tokio"], version = "0.7" }
 tokio = { default-features = false, features = ["macros", "rt-multi-thread"], version = "1.0" }
 tokio-postgres = { default-features = false, features = ["runtime"], version = "0.7" }
+diesel-async = { default-features = false, features = ["postgres"], version = "0.4.1" }
+diesel = { default-features = false, version = "2.1" }
 wtx = { default-features = false, features = ["atoi", "postgres", "simdutf8", "tokio", "web-socket-handshake"], path = "../wtx" }
 
 [package]

--- a/wtx-bench/src/main.rs
+++ b/wtx-bench/src/main.rs
@@ -29,9 +29,14 @@ async fn main() {
         let mut sqlx_postgres = misc::Agent { name: "sqlx-postgres-tokio".to_owned(), result: 0 };
         let mut tokio_postgres = misc::Agent { name: "tokio-postgres".to_owned(), result: 0 };
         let mut wtx = misc::Agent { name: "wtx-tokio".to_owned(), result: 0 };
-        postgres::bench(&up, [&mut sqlx_postgres, &mut tokio_postgres, &mut wtx]).await;
+        let mut diesel_async = misc::Agent { name: "diesel_async".to_owned(), result: 0 };
+        postgres::bench(
+          &up,
+          [&mut sqlx_postgres, &mut tokio_postgres, &mut wtx, &mut diesel_async],
+        )
+        .await;
         misc::flush(
-          &[sqlx_postgres, tokio_postgres, wtx],
+          &[sqlx_postgres, tokio_postgres, wtx, diesel_async],
           &postgres::caption(),
           "/tmp/wtx-postgres.png",
         );

--- a/wtx-bench/src/postgres.rs
+++ b/wtx-bench/src/postgres.rs
@@ -125,6 +125,7 @@ async fn bench_wtx(agent: &mut Agent, up: &UriPartsRef<'_>) {
   agent.result = instant.elapsed().as_millis();
 }
 
+#[allow(clippy::single_char_lifetime_names, unused_qualifications, clippy::shadow_unrelated)]
 async fn bench_diesel_async(agent: &mut Agent, up: &UriPartsRef<'_>) {
   use diesel::prelude::*;
   use diesel_async::RunQueryDsl;

--- a/wtx-bench/src/postgres.rs
+++ b/wtx-bench/src/postgres.rs
@@ -1,4 +1,5 @@
 use crate::misc::Agent;
+use diesel_async::AsyncPgConnection;
 use futures::stream::StreamExt;
 use sqlx::{Connection, Either, Executor as _, Row};
 use std::time::Instant;
@@ -22,12 +23,13 @@ const QUERIES: usize = 1024;
 
 pub(crate) async fn bench(
   up: &UriPartsRef<'_>,
-  [sqlx_postgres, tokio_postgres, wtx]: [&mut Agent; 3],
+  [sqlx_postgres, tokio_postgres, wtx, diesel_async]: [&mut Agent; 4],
 ) {
   populate_db(&mut StdRng::default(), up).await;
   bench_sqlx_postgres(sqlx_postgres, up).await;
   bench_tokio_postgres(tokio_postgres, up).await;
   bench_wtx(wtx, up).await;
+  bench_diesel_async(diesel_async, up).await;
 }
 
 async fn bench_sqlx_postgres(agent: &mut Agent, up: &UriPartsRef<'_>) {
@@ -113,6 +115,54 @@ async fn bench_wtx(agent: &mut Agent, up: &UriPartsRef<'_>) {
           assert!(!records.record(0).unwrap().decode::<_, &str>("baz").unwrap().is_empty());
           assert!(!records.record(1).unwrap().decode::<_, &str>("bar").unwrap().is_empty());
           assert!(!records.record(1).unwrap().decode::<_, &str>("baz").unwrap().is_empty());
+        }
+      }
+    });
+  }
+  while let Some(rslt) = set.join_next().await {
+    rslt.unwrap();
+  }
+  agent.result = instant.elapsed().as_millis();
+}
+
+async fn bench_diesel_async(agent: &mut Agent, up: &UriPartsRef<'_>) {
+  use diesel::prelude::*;
+  use diesel_async::RunQueryDsl;
+
+  table! {
+    foo(bar, baz) {
+      bar -> Text,
+      baz -> Text,
+    }
+  }
+
+  let instant = Instant::now();
+  let mut set = JoinSet::new();
+  for _ in 0..CONNECTIONS {
+    let _handle = set.spawn({
+      let local_up = up.clone().into_string();
+      async move {
+        let (client, conn) = tokio_postgres::Config::new()
+          .host(local_up.hostname())
+          .user(local_up.user())
+          .port(local_up.port().parse().unwrap())
+          .password(local_up.password())
+          .dbname(local_up.path().get(1..).unwrap())
+          .connect(NoTls)
+          .await
+          .unwrap();
+        let _handle = tokio::spawn(async move {
+          if let Err(e) = conn.await {
+            println!("Error: {e}");
+          }
+        });
+        let mut conn = AsyncPgConnection::try_from(client).await.unwrap();
+        for _ in 0..QUERIES {
+          let records = foo::table.load::<(String, String)>(&mut conn).await.unwrap();
+          assert!(!records[0].0.is_empty());
+          assert!(!records[0].1.is_empty());
+          assert!(!records[1].0.is_empty());
+          assert!(!records[1].1.is_empty());
         }
       }
     });

--- a/wtx-bench/src/postgres.rs
+++ b/wtx-bench/src/postgres.rs
@@ -82,8 +82,9 @@ async fn bench_tokio_postgres(agent: &mut Agent, up: &UriPartsRef<'_>) {
             println!("Error: {e}");
           }
         });
+        let p = client.prepare("SELECT * FROM foo").await.unwrap();
         for _ in 0..QUERIES {
-          let rows = client.query("SELECT * FROM foo", &[]).await.unwrap();
+          let rows = client.query(&p, &[]).await.unwrap();
           assert!(!rows[0].get::<_, &str>("bar").is_empty());
           assert!(!rows[0].get::<_, &str>("baz").is_empty());
           assert!(!rows[1].get::<_, &str>("bar").is_empty());


### PR DESCRIPTION
This PR fixes the tokio-postgres benchmark to also cache prepared statements. It also adds `diesel-async` as another potential backend. I now get the following results locally:

![wtx-postgres](https://github.com/c410-f3r/wtx/assets/1674512/25832439-4ff2-498e-abc1-f8c19d7f7100)




If you are interested in a more complete set of benchmarks consider contributing your driver to https://github.com/diesel-rs/diesel/tree/master/diesel_bench