### PR TITLE
Primitive Implementation for `Encode` and `Decode` for `Vec<String>`

### DIFF
--- a/wtx/src/database/client/postgres/tys.rs
+++ b/wtx/src/database/client/postgres/tys.rs
@@ -385,11 +385,11 @@ mod collections {
     E: From<crate::Error>,
   {
     #[inline]
-    fn encode(&self, ev: &mut EncodeValue<'_, '_>) -> Result<(), E> {
+    fn encode(&self, ev: &mut EncodeValue<'_, '_>) -> Result<(), E> {/*
       ev.fbw().extend_from_slice(&1_u32.to_be_bytes())?;
       ev.fbw().extend_from_slice(&0_u32.to_be_bytes())?;
       ev.fbw().extend_from_slice(&25_u32.to_be_bytes())?;
-      ev.fbw().extend_from_slice(&self.len().to_be_bytes())?;
+      ev.fbw().extend_from_slice(&self.len().to_be_bytes())?;*/
 
       for s in self {
         ev.fbw().extend_from_slice(&s.len().to_be_bytes())?;

--- a/wtx/src/database/client/postgres/tys.rs
+++ b/wtx/src/database/client/postgres/tys.rs
@@ -386,13 +386,13 @@ mod collections {
   {
     #[inline]
     fn encode(&self, ev: &mut EncodeValue<'_, '_>) -> Result<(), E> {
-      ev.fbw().extend_from_slice(1.to_be_bytes())?;
-      ev.fbw().extend_from_slice(0.to_be_bytes())?;
-      ev.fbw().extend_from_slice(25.to_be_bytes())?;
-      ev.fbw().extend_from_slice(self.len().to_be_bytes())?;
+      ev.fbw().extend_from_slice(&1_u32.to_be_bytes())?;
+      ev.fbw().extend_from_slice(&0_u32.to_be_bytes())?;
+      ev.fbw().extend_from_slice(&25_u32.to_be_bytes())?;
+      ev.fbw().extend_from_slice(&self.len().to_be_bytes())?;
 
       for s in self {
-        ev.fbw().extend_from_slice(s.len().to_be_bytes())?;
+        ev.fbw().extend_from_slice(&s.len().to_be_bytes())?;
         ev.fbw().extend_from_slice(s.as_bytes())?;
       }
       Ok(())


### PR DESCRIPTION
This is an incredibly primitive implementation for the decoding and encoding of the raw bytes into and from a `Vec<String>`.

Please leave comments so we can iterate on this.