### PR TITLE
Increase the maximum allowed number of characters a header value can have

### DIFF
--- a/wtx/src/http.rs
+++ b/wtx/src/http.rs
@@ -63,7 +63,7 @@ pub use version::Version;
 /// Maximum number of bytes for the name of a header.
 pub const MAX_HEADER_NAME_LEN: usize = 128;
 /// Maximum number of bytes for the value of a header.
-pub const MAX_HEADER_VALUE_LEN: usize = 1024 * 2 + 128;
+pub const MAX_HEADER_VALUE_LEN: usize = 1024 * 3;
 /// Current user agent of this project
 pub const WTX_USER_AGENT: &str = concat!("wtx/", env!("CARGO_PKG_VERSION"));
 


### PR DESCRIPTION
Should be large enough for the majority of cases