### PR TITLE
Interpret header values as strings

### DIFF
--- a/wtx-ui/src/http_client.rs
+++ b/wtx-ui/src/http_client.rs
@@ -20,7 +20,7 @@ pub(crate) async fn http_client(http_client: HttpClient) {
       .headers
       .push_from_iter(Header::from_name_and_value(
         name.trim(),
-        values.split(',').map(|el| el.trim().as_bytes()),
+        values.split(',').map(|el| el.trim()),
       ))
       .unwrap();
   }
@@ -29,7 +29,7 @@ pub(crate) async fn http_client(http_client: HttpClient) {
       .headers
       .push_from_iter(Header::from_name_and_value(
         KnownHeaderName::UserAgent.into(),
-        [elem.as_bytes()],
+        [elem.as_str()],
       ))
       .unwrap();
   }

--- a/wtx/src/client_api_framework/network/transport/wtx_http.rs
+++ b/wtx/src/client_api_framework/network/transport/wtx_http.rs
@@ -91,12 +91,12 @@ where
   let HttpReqParams { headers, mime, .. } = &mut params.ext_params_mut().0;
   headers.push_from_iter(Header::from_name_and_value(
     KnownHeaderName::UserAgent.into(),
-    [WTX_USER_AGENT.as_bytes()],
+    [WTX_USER_AGENT],
   ))?;
   if let Some(elem) = mime {
     headers.push_from_iter(Header::from_name_and_value(
       KnownHeaderName::ContentType.into(),
-      [elem.as_str().as_bytes()],
+      [elem.as_str()],
     ))?;
   }
   Ok(())

--- a/wtx/src/grpc/grpc_client.rs
+++ b/wtx/src/grpc/grpc_client.rs
@@ -68,13 +68,10 @@ where
     headers.push_from_iter_many([
       Header::from_name_and_value(
         KnownHeaderName::ContentType.into(),
-        ["application/grpc".as_bytes()].into_iter(),
+        ["application/grpc"].into_iter(),
       ),
-      Header::from_name_and_value(KnownHeaderName::Te.into(), ["trailers".as_bytes()].into_iter()),
-      Header::from_name_and_value(
-        KnownHeaderName::UserAgent.into(),
-        [WTX_USER_AGENT.as_bytes()].into_iter(),
-      ),
+      Header::from_name_and_value(KnownHeaderName::Te.into(), ["trailers"].into_iter()),
+      Header::from_name_and_value(KnownHeaderName::UserAgent.into(), [WTX_USER_AGENT].into_iter()),
     ])?;
     Ok(())
   }

--- a/wtx/src/grpc/grpc_middleware.rs
+++ b/wtx/src/grpc/grpc_middleware.rs
@@ -31,13 +31,13 @@ where
     req.rrd.headers.push_from_iter_many([
       Header::from_name_and_value(
         KnownHeaderName::ContentType.into(),
-        [Mime::ApplicationGrpc.as_str().as_bytes()].into_iter(),
+        [Mime::ApplicationGrpc.as_str()].into_iter(),
       ),
       Header {
         is_sensitive: false,
         is_trailer: true,
         name: "grpc-status",
-        value: [stream_aux.status_code_mut()._number_as_str().as_bytes()].into_iter(),
+        value: [stream_aux.status_code_mut()._number_as_str()].into_iter(),
       },
     ])?;
     Ok(ControlFlow::Continue(()))

--- a/wtx/src/http/misc.rs
+++ b/wtx/src/http/misc.rs
@@ -13,7 +13,7 @@ pub fn is_web_socket_handshake(
   let bytes = KnownHeaderName::SecWebsocketVersion.into();
   method == Method::Connect
     && protocol == Some(Protocol::WebSocket)
-    && headers.get_by_name(bytes).map(|el| el.value) == Some(b"13")
+    && headers.get_by_name(bytes).map(|el| el.value) == Some("13")
 }
 
 /// Used as an auxiliary tool for tests.

--- a/wtx/src/http/server_framework/arguments/serde_json.rs
+++ b/wtx/src/http/server_framework/arguments/serde_json.rs
@@ -83,7 +83,7 @@ where
 fn push_content_type(req: &mut Request<ReqResBuffer>) -> crate::Result<()> {
   req.rrd.lease_mut().headers.push_from_iter(Header::from_name_and_value(
     KnownHeaderName::ContentType.into(),
-    [Mime::ApplicationJson.as_str().as_bytes()],
+    [Mime::ApplicationJson.as_str()],
   ))?;
   Ok(())
 }

--- a/wtx/src/http/server_framework/methods.rs
+++ b/wtx/src/http/server_framework/methods.rs
@@ -21,10 +21,10 @@ fn check_json<E>(headers: &Headers, method: Method) -> Result<(), E>
 where
   E: From<crate::Error>,
 {
-  if headers
+  let header = headers
     .get_by_name(KnownHeaderName::ContentType.into())
-    .is_none_or(|el| el.value != Mime::ApplicationJson.as_str().as_bytes())
-  {
+    .ok_or(crate::Error::from(HttpError::MissingHeader(KnownHeaderName::ContentType)))?;
+  if header.value != Mime::ApplicationJson.as_str() {
     return Err(E::from(crate::Error::from(HttpError::UnexpectedContentType)));
   }
   if method != Method::Post {

--- a/wtx/src/http/server_framework/redirect.rs
+++ b/wtx/src/http/server_framework/redirect.rs
@@ -57,10 +57,7 @@ impl Redirect {
 
   #[inline]
   fn push_headers(headers: &mut Headers, uri: &str) -> crate::Result<()> {
-    headers.push_from_iter(Header::from_name_and_value(
-      KnownHeaderName::Location.into(),
-      [uri.as_bytes()],
-    ))?;
+    headers.push_from_iter(Header::from_name_and_value(KnownHeaderName::Location.into(), [uri]))?;
     Ok(())
   }
 }

--- a/wtx/src/http/session/session_decoder.rs
+++ b/wtx/src/http/session/session_decoder.rs
@@ -70,7 +70,7 @@ where
       }
       let ss_des: SessionState<CS> = {
         let idx = req.rrd.body.len();
-        let cookie_des = CookieBytes::parse(header.value, &mut req.rrd.body)?;
+        let cookie_des = CookieBytes::parse(header.value.as_bytes(), &mut req.rrd.body)?;
         if cookie_des.generic.name != cookie_def.name {
           continue;
         }

--- a/wtx/src/http/session/session_manager.rs
+++ b/wtx/src/http/session/session_manager.rs
@@ -8,7 +8,10 @@ use crate::{
   misc::{GenericTime, Lease, LeaseMut, Lock, Rng, Vector},
 };
 use chrono::{DateTime, TimeDelta, Utc};
-use core::marker::PhantomData;
+use core::{
+  fmt::{Debug, Formatter},
+  marker::PhantomData,
+};
 use serde::Serialize;
 
 /// [`SessionManager`] backed by `tokio`
@@ -134,9 +137,18 @@ where
 }
 
 /// Allows the management of state across requests within a connection.
-#[derive(Debug)]
 pub struct SessionManagerInner<CS, E> {
   pub(crate) cookie_def: CookieGeneric<&'static [u8], Vector<u8>>,
   pub(crate) key: SessionKey,
   pub(crate) phantom: PhantomData<(CS, E)>,
+}
+
+impl<CS, E> Debug for SessionManagerInner<CS, E> {
+  #[inline]
+  fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+    f.debug_struct("SessionManagerInner")
+      .field("cookie_def", &self.cookie_def)
+      .field("phantom", &self.phantom)
+      .finish()
+  }
 }

--- a/wtx/src/http2/client_stream.rs
+++ b/wtx/src/http2/client_stream.rs
@@ -142,11 +142,11 @@ where
       req.rrd.headers(),
       (
         HpackStaticRequestHeaders {
-          authority: uri.authority().as_bytes(),
+          authority: uri.authority(),
           method: Some(req.method),
-          path: uri.relative_reference_slash().as_bytes(),
+          path: uri.relative_reference_slash(),
           protocol: None,
-          scheme: uri.scheme().as_bytes(),
+          scheme: uri.scheme(),
         },
         HpackStaticResponseHeaders::EMPTY,
       ),

--- a/wtx/src/http2/hpack_header.rs
+++ b/wtx/src/http2/hpack_header.rs
@@ -15,7 +15,7 @@ pub(crate) enum HpackHeaderBasic {
 }
 
 impl HpackHeaderBasic {
-  pub(crate) const fn len(self, name: &str, value: &[u8]) -> usize {
+  pub(crate) const fn len(self, name: &str, value: &str) -> usize {
     match self {
       HpackHeaderBasic::Authority => 10usize.wrapping_add(value.len()).wrapping_add(32),
       HpackHeaderBasic::Field => name.len().wrapping_add(value.len()).wrapping_add(32),
@@ -28,11 +28,11 @@ impl HpackHeaderBasic {
   }
 }
 
-impl TryFrom<(HpackHeaderName, &[u8])> for HpackHeaderBasic {
+impl TryFrom<(HpackHeaderName, &str)> for HpackHeaderBasic {
   type Error = crate::Error;
 
   #[inline]
-  fn try_from(from: (HpackHeaderName, &[u8])) -> Result<Self, Self::Error> {
+  fn try_from(from: (HpackHeaderName, &str)) -> Result<Self, Self::Error> {
     Ok(match from.0 {
       HpackHeaderName::Authority => HpackHeaderBasic::Authority,
       HpackHeaderName::Field => HpackHeaderBasic::Field,

--- a/wtx/src/http2/hpack_headers.rs
+++ b/wtx/src/http2/hpack_headers.rs
@@ -64,7 +64,7 @@ where
       return Ok(());
     }
     self.remove_until_max_bytes(local_len, cb);
-    self.bq.push_front_from_coyable_data(
+    self.bq.push_front_from_copyable_data(
       [name.as_bytes()].into_iter().chain(iter),
       Metadata { is_sensitive, misc, name_len: name.len() },
     )?;

--- a/wtx/src/http2/hpack_static_headers.rs
+++ b/wtx/src/http2/hpack_static_headers.rs
@@ -6,23 +6,23 @@ use crate::{
 /// Mandatory headers of a HTTP/2 request
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct HpackStaticRequestHeaders<'bytes> {
-  pub(crate) authority: &'bytes [u8],
+  pub(crate) authority: &'bytes str,
   pub(crate) method: Option<Method>,
-  pub(crate) path: &'bytes [u8],
+  pub(crate) path: &'bytes str,
   pub(crate) protocol: Option<Protocol>,
-  pub(crate) scheme: &'bytes [u8],
+  pub(crate) scheme: &'bytes str,
 }
 
 impl HpackStaticRequestHeaders<'_> {
   pub(crate) const EMPTY: Self =
-    Self { authority: &[], method: None, path: &[], protocol: None, scheme: &[] };
+    Self { authority: "", method: None, path: "", protocol: None, scheme: "" };
 
   #[inline]
-  pub(crate) fn iter(&self) -> impl Iterator<Item = (HpackHeaderBasic, &[u8])> {
+  pub(crate) fn iter(&self) -> impl Iterator<Item = (HpackHeaderBasic, &str)> {
     let Self { authority, method, path, protocol, scheme } = *self;
     let enums = [
-      method.map(|el| (HpackHeaderBasic::Method(el), &[][..])),
-      protocol.map(|el| (HpackHeaderBasic::Protocol(el), &[][..])),
+      method.map(|el| (HpackHeaderBasic::Method(el), "")),
+      protocol.map(|el| (HpackHeaderBasic::Protocol(el), "")),
     ]
     .into_iter()
     .flatten();
@@ -46,8 +46,8 @@ pub(crate) struct HpackStaticResponseHeaders {
 impl HpackStaticResponseHeaders {
   pub(crate) const EMPTY: Self = Self { status_code: None };
 
-  pub(crate) fn iter(&self) -> impl Iterator<Item = (HpackHeaderBasic, &[u8])> {
+  pub(crate) fn iter(&self) -> impl Iterator<Item = (HpackHeaderBasic, &str)> {
     let Self { status_code } = *self;
-    status_code.map(|el| (HpackHeaderBasic::StatusCode(el), &[][..])).into_iter()
+    status_code.map(|el| (HpackHeaderBasic::StatusCode(el), "")).into_iter()
   }
 }

--- a/wtx/src/http2/huffman.rs
+++ b/wtx/src/http2/huffman.rs
@@ -136,39 +136,6 @@ pub(crate) fn huffman_encode(from: &[u8], wb: &mut Vector<u8>) -> crate::Result<
   Ok(())
 }
 
-#[cfg(all(feature = "_bench", test))]
-mod bench {
-  use crate::{
-    bench::_data,
-    http2::huffman::{huffman_decode, huffman_encode},
-    misc::{ArrayVector, Vector},
-  };
-  use alloc::boxed::Box;
-
-  #[bench]
-  fn decode(b: &mut test::Bencher) {
-    const N: usize = 1024 * 512;
-    let data = {
-      let mut dest = Vector::with_capacity(N).unwrap();
-      huffman_encode(&_data(N), &mut dest).unwrap();
-      dest
-    };
-    let mut dest = Box::new(ArrayVector::<_, N>::default());
-    b.iter(|| {
-      let _ = huffman_decode(&data, &mut dest).unwrap();
-      dest.clear();
-    });
-  }
-
-  #[bench]
-  fn encode(b: &mut test::Bencher) {
-    const N: usize = 1024 * 1024 * 4;
-    let mut data = _data(N);
-    let mut dest = Vector::with_capacity(N).unwrap();
-    b.iter(|| huffman_encode(&mut data, &mut dest));
-  }
-}
-
 #[cfg(kani)]
 mod kani {
   use crate::{

--- a/wtx/src/http2/tests/connections.rs
+++ b/wtx/src/http2/tests/connections.rs
@@ -34,7 +34,7 @@ async fn client(uri: &UriString) {
   _0(rrb.body(), rrb.headers());
 
   rrb.clear();
-  rrb.headers.push_from_iter(Header::from_name_and_value("123", ["456".as_bytes()])).unwrap();
+  rrb.headers.push_from_iter(Header::from_name_and_value("123", ["456"])).unwrap();
   rrb = stream_client(&mut http2, rrb, &uri_ref).await;
   _1(rrb.body(), rrb.headers());
 
@@ -45,7 +45,7 @@ async fn client(uri: &UriString) {
 
   rrb.clear();
   rrb.body.extend_from_copyable_slice(b"123").unwrap();
-  rrb.headers.push_from_iter(Header::from_name_and_value("123", ["456".as_bytes()])).unwrap();
+  rrb.headers.push_from_iter(Header::from_name_and_value("123", ["456"])).unwrap();
   rrb = stream_client(&mut http2, rrb, &uri_ref).await;
   _3(rrb.body(), rrb.headers());
 

--- a/wtx/src/misc/blocks_deque.rs
+++ b/wtx/src/misc/blocks_deque.rs
@@ -205,7 +205,7 @@ impl<D, M> BlocksDeque<D, M> {
 
   /// Prepends a block to the queue.
   #[inline]
-  pub fn push_front_from_coyable_data<'data, I>(&mut self, data: I, misc: M) -> crate::Result<()>
+  pub fn push_front_from_copyable_data<'data, I>(&mut self, data: I, misc: M) -> crate::Result<()>
   where
     D: Copy + 'data,
     I: IntoIterator<Item = &'data [D]>,

--- a/wtx/src/misc/blocks_deque/tests.rs
+++ b/wtx/src/misc/blocks_deque/tests.rs
@@ -30,22 +30,22 @@ fn pop_back() {
   let mut bq = BlocksDeque::with_exact_capacity(4, 8).unwrap();
   check_state(&bq, 0, 0, &[], &[]);
 
-  bq.push_front_from_coyable_data([&[1][..]], ()).unwrap();
+  bq.push_front_from_copyable_data([&[1][..]], ()).unwrap();
   check_state(&bq, 1, 1, &[1], &[]);
 
-  bq.push_front_from_coyable_data([&[2, 3][..]], ()).unwrap();
+  bq.push_front_from_copyable_data([&[2, 3][..]], ()).unwrap();
   check_state(&bq, 2, 3, &[2, 3, 1], &[]);
 
-  bq.push_front_from_coyable_data([&[4, 5], &[6][..]], ()).unwrap();
+  bq.push_front_from_copyable_data([&[4, 5], &[6][..]], ()).unwrap();
   check_state(&bq, 3, 6, &[4, 5, 6, 2, 3, 1], &[]);
 
-  bq.push_front_from_coyable_data([&[7, 8][..]], ()).unwrap();
+  bq.push_front_from_copyable_data([&[7, 8][..]], ()).unwrap();
   check_state(&bq, 4, 8, &[7, 8, 4, 5, 6, 2, 3, 1], &[]);
 
   let _ = bq.pop_back();
   check_state(&bq, 3, 7, &[7, 8, 4, 5, 6, 2, 3], &[]);
 
-  bq.push_front_from_coyable_data([&[9][..]], ()).unwrap();
+  bq.push_front_from_copyable_data([&[9][..]], ()).unwrap();
   check_state(&bq, 4, 8, &[9], &[7, 8, 4, 5, 6, 2, 3]);
 
   let _ = bq.pop_back();
@@ -54,10 +54,10 @@ fn pop_back() {
   let _ = bq.pop_back();
   check_state(&bq, 2, 3, &[9], &[7, 8]);
 
-  bq.push_front_from_coyable_data([&[10], &[11, 12][..]], ()).unwrap();
+  bq.push_front_from_copyable_data([&[10], &[11, 12][..]], ()).unwrap();
   check_state(&bq, 3, 6, &[10, 11, 12, 9], &[7, 8]);
 
-  bq.push_front_from_coyable_data([&[13, 14][..]], ()).unwrap();
+  bq.push_front_from_copyable_data([&[13, 14][..]], ()).unwrap();
   check_state(&bq, 4, 8, &[13, 14, 10, 11, 12, 9], &[7, 8]);
 
   let _ = bq.pop_back();
@@ -69,10 +69,10 @@ fn pop_back() {
   let _ = bq.pop_back();
   check_state(&bq, 1, 2, &[13, 14], &[]);
 
-  bq.push_front_from_coyable_data([&[15][..]], ()).unwrap();
+  bq.push_front_from_copyable_data([&[15][..]], ()).unwrap();
   check_state(&bq, 2, 3, &[15, 13, 14], &[]);
 
-  bq.push_front_from_coyable_data([&[16][..]], ()).unwrap();
+  bq.push_front_from_copyable_data([&[16][..]], ()).unwrap();
   check_state(&bq, 3, 4, &[16, 15, 13, 14], &[]);
 
   let _ = bq.pop_back();
@@ -95,10 +95,10 @@ fn pop_front() {
   let mut bq = BlocksDeque::with_exact_capacity(2, 8).unwrap();
   check_state(&bq, 0, 0, &[], &[]);
 
-  bq.push_front_from_coyable_data([&[1, 2, 3][..]], ()).unwrap();
+  bq.push_front_from_copyable_data([&[1, 2, 3][..]], ()).unwrap();
   check_state(&bq, 1, 3, &[1, 2, 3], &[]);
 
-  bq.push_front_from_coyable_data([&[4, 5], &[6, 7, 8][..]], ()).unwrap();
+  bq.push_front_from_copyable_data([&[4, 5], &[6, 7, 8][..]], ()).unwrap();
   check_state(&bq, 2, 8, &[4, 5, 6, 7, 8, 1, 2, 3], &[]);
 
   let _ = bq.pop_front();
@@ -114,12 +114,12 @@ fn pop_front() {
 fn push_reserve_and_push() {
   let mut bq = BlocksDeque::new();
   bq.reserve_front(1, 4).unwrap();
-  bq.push_front_from_coyable_data([&[0, 1, 2, 3][..]], ()).unwrap();
+  bq.push_front_from_copyable_data([&[0, 1, 2, 3][..]], ()).unwrap();
   check_state(&bq, 1, 4, &[0, 1, 2, 3], &[]);
   assert_eq!(bq.get(0), Some(BlockRef { data: &[0, 1, 2, 3], misc: &(), range: 0..4 }));
   assert_eq!(bq.get(1), None);
   bq.reserve_front(1, 6).unwrap();
-  bq.push_front_from_coyable_data([&[4, 5, 6, 7, 8, 9][..]], ()).unwrap();
+  bq.push_front_from_copyable_data([&[4, 5, 6, 7, 8, 9][..]], ()).unwrap();
   check_state(&bq, 2, 10, &[4, 5, 6, 7, 8, 9, 0, 1, 2, 3], &[]);
   assert_eq!(bq.get(0), Some(BlockRef { data: &[4, 5, 6, 7, 8, 9], misc: &(), range: 0..6 }));
   assert_eq!(bq.get(1), Some(BlockRef { data: &[0, 1, 2, 3], misc: &(), range: 6..10 }));
@@ -161,7 +161,7 @@ fn wrap_initial() -> BlocksDeque<i32, ()> {
   let mut bq = BlocksDeque::with_exact_capacity(6, 8).unwrap();
   check_state(&bq, 0, 0, &[], &[]);
   for _ in 0..6 {
-    bq.push_front_from_coyable_data([&[0][..]], ()).unwrap();
+    bq.push_front_from_copyable_data([&[0][..]], ()).unwrap();
   }
   check_state(&bq, 6, 6, &[0, 0, 0, 0, 0, 0], &[]);
   for idx in 0..6 {
@@ -174,7 +174,7 @@ fn wrap_initial() -> BlocksDeque<i32, ()> {
   check_state(&bq, 2, 2, &[0, 0], &[]);
   assert_eq!(bq.get(0).unwrap().data, &[0]);
   assert_eq!(bq.get(1).unwrap().data, &[0]);
-  bq.push_front_from_coyable_data([&[1, 2, 3][..]], ()).unwrap();
+  bq.push_front_from_copyable_data([&[1, 2, 3][..]], ()).unwrap();
   check_state(&bq, 3, 5, &[1, 2, 3, 0, 0], &[]);
   assert_eq!(bq.get(0).unwrap().data, &[1, 2, 3]);
   assert_eq!(bq.get(1).unwrap().data, &[0]);


### PR DESCRIPTION
The spec does not allow the storing and reading of arbitrary bytes