### PR TITLE
Fix namespace typos

### DIFF
--- a/wtx/src/http/server_framework/cors_middleware.rs
+++ b/wtx/src/http/server_framework/cors_middleware.rs
@@ -7,7 +7,7 @@ use crate::{
   misc::{Intersperse, Vector, str_split1},
 };
 use alloc::string::String;
-use core::ops::ControlFlow;
+use core::{ops::ControlFlow, str};
 use hashbrown::HashSet;
 
 type AllowHeaders = (bool, Vector<String>);
@@ -443,9 +443,9 @@ where
         self
           .apply_preflight_response(
             // SAFETY: Every single element of `req.rrd.bod` was previously inserted with UTF-8
-            unsafe { std::str::from_utf8_unchecked(headers_bytes) },
+            unsafe { str::from_utf8_unchecked(headers_bytes) },
             // SAFETY: Every single element of `req.rrd.bod` was previously inserted with UTF-8
-            unsafe { std::str::from_utf8_unchecked(origin_bytes) },
+            unsafe { str::from_utf8_unchecked(origin_bytes) },
             &mut req.rrd.headers,
           )
           .await?;

--- a/wtx/src/http/server_framework/cors_middleware.rs
+++ b/wtx/src/http/server_framework/cors_middleware.rs
@@ -443,9 +443,9 @@ where
         self
           .apply_preflight_response(
             // SAFETY: Every single element of `req.rrd.bod` was previously inserted with UTF-8
-            unsafe { str::from_utf8_unchecked(headers_bytes) },
+            unsafe { std::str::from_utf8_unchecked(headers_bytes) },
             // SAFETY: Every single element of `req.rrd.bod` was previously inserted with UTF-8
-            unsafe { str::from_utf8_unchecked(origin_bytes) },
+            unsafe { std::str::from_utf8_unchecked(origin_bytes) },
             &mut req.rrd.headers,
           )
           .await?;

--- a/wtx/src/http2/hpack_decoder.rs
+++ b/wtx/src/http2/hpack_decoder.rs
@@ -333,7 +333,7 @@ impl HpackDecoder {
               *el.misc,
               (HeaderName::new_unchecked(""), HeaderName::new_unchecked(el.name_bytes)),
               // SAFETY: Everything previously inserted in `dyn_headers` is UTF-8
-              ("", unsafe { str::from_utf8_unchecked(el.value_bytes) }),
+              ("", unsafe { std::str::from_utf8_unchecked(el.value_bytes) }),
             )
           })
           .ok_or_else(|| {

--- a/wtx/src/http2/hpack_decoder.rs
+++ b/wtx/src/http2/hpack_decoder.rs
@@ -10,6 +10,7 @@ use crate::{
   misc::{Usize, from_utf8_basic},
 };
 use alloc::boxed::Box;
+use core::str;
 
 const DYN_IDX_OFFSET: usize = 62;
 
@@ -154,7 +155,7 @@ impl HpackDecoder {
         self.header_buffers.0.extend_from_copyable_slice(dyn_name.str().as_bytes())?;
         let bytes = self.header_buffers.0.get_mut(..dyn_name.str().len()).unwrap_or_default();
         // SAFETY: Just a temporary copy of an already existing string
-        unsafe { core::str::from_utf8_unchecked(bytes) }
+        unsafe { str::from_utf8_unchecked(bytes) }
       } else {
         elem_cb((new_hhb, static_name, value))?;
         static_name.str()
@@ -333,7 +334,7 @@ impl HpackDecoder {
               *el.misc,
               (HeaderName::new_unchecked(""), HeaderName::new_unchecked(el.name_bytes)),
               // SAFETY: Everything previously inserted in `dyn_headers` is UTF-8
-              ("", unsafe { std::str::from_utf8_unchecked(el.value_bytes) }),
+              ("", unsafe { str::from_utf8_unchecked(el.value_bytes) }),
             )
           })
           .ok_or_else(|| {


### PR DESCRIPTION
Hello there,

there seems to be a typo in the file `hpack-decoder.rs`. By adding the `std` namespace the library compiles without errors.