### PR TITLE
[WebSocket] Fix control frames

### DIFF
--- a/wtx-instances/http2-examples/http2-server.rs
+++ b/wtx-instances/http2-examples/http2-server.rs
@@ -1,8 +1,10 @@
-//! HTTP/2 server that uses optioned parameters.
+//! Low-level HTTP/2 server that uses optioned parameters.
 //!
 //! Automatic streams are handled by the system while manual stream are handled by the user. In
 //! this particular example all manual streams are considered to be WebSocket connections over
 //! HTTP/2.
+//!
+//! Please note that it is much easier to just use the HTTP server framework.
 
 extern crate tokio;
 extern crate tokio_rustls;


### PR DESCRIPTION
Fix #405

Stops the automatic masking of control frames that are automatically sent to peers.