### PR TITLE
Add the `TryExtend` trait

### DIFF
--- a/wtx/src/collection.rs
+++ b/wtx/src/collection.rs
@@ -12,6 +12,7 @@ mod deque;
 mod expansion_ty;
 mod linear_storage;
 mod misc;
+mod try_extend;
 mod vector;
 
 pub use array_string::{
@@ -28,4 +29,5 @@ pub use deque::{Deque, DequeueError};
 pub use expansion_ty::ExpansionTy;
 pub use linear_storage::linear_storage_len::LinearStorageLen;
 pub use misc::backward_deque_idx;
+pub use try_extend::TryExtend;
 pub use vector::{Vector, VectorError};

--- a/wtx/src/collection/try_extend.rs
+++ b/wtx/src/collection/try_extend.rs
@@ -1,0 +1,66 @@
+use crate::collection::Vector;
+use alloc::vec::Vec;
+
+/// A trait for extending collections with fallible operations.
+pub trait TryExtend<S>
+where
+  S: ?Sized,
+{
+  /// Custom error
+  type Error;
+
+  /// Attempts to extend this instance with elements from the given `set` source.
+  fn try_extend(&mut self, set: &mut S) -> Result<(), Self::Error>;
+}
+
+impl<T> TryExtend<[T]> for Vec<T>
+where
+  T: Copy,
+{
+  type Error = crate::Error;
+
+  #[inline]
+  fn try_extend(&mut self, set: &mut [T]) -> Result<(), Self::Error> {
+    self.copy_from_slice(set);
+    Ok(())
+  }
+}
+
+impl<I, T> TryExtend<I> for Vec<T>
+where
+  I: Iterator<Item = T>,
+{
+  type Error = crate::Error;
+
+  #[inline]
+  fn try_extend(&mut self, set: &mut I) -> Result<(), Self::Error> {
+    self.extend(set);
+    Ok(())
+  }
+}
+
+impl<T> TryExtend<[T]> for Vector<T>
+where
+  T: Copy,
+{
+  type Error = crate::Error;
+
+  #[inline]
+  fn try_extend(&mut self, set: &mut [T]) -> Result<(), Self::Error> {
+    self.extend_from_copyable_slice(set)?;
+    Ok(())
+  }
+}
+
+impl<I, T> TryExtend<I> for Vector<T>
+where
+  I: Iterator<Item = T>,
+{
+  type Error = crate::Error;
+
+  #[inline]
+  fn try_extend(&mut self, set: &mut I) -> Result<(), Self::Error> {
+    self.extend_from_iter(set)?;
+    Ok(())
+  }
+}

--- a/wtx/src/database/client/postgres/tys/calendar.rs
+++ b/wtx/src/database/client/postgres/tys/calendar.rs
@@ -69,7 +69,7 @@ where
       return Err(E::from(PostgresError::TimeStructureOverflow.into()));
     }
     let (this_ts, this_ns) = self.timestamp();
-    if this_ns.num() % 1_000 > 0 {
+    if !this_ns.num().is_multiple_of(1_000) {
       return Err(E::from(PostgresError::TimeStructureWithGreaterPrecision.into()));
     }
     let this_us = this_ns.num() / 1_000;

--- a/wtx/src/database/client/postgres/tys/rust_decimal.rs
+++ b/wtx/src/database/client/postgres/tys/rust_decimal.rs
@@ -82,7 +82,7 @@ where
     digits.reverse();
 
     let after_decimal = scale.wrapping_add(3) / 4;
-    let weight = digits.len().wrapping_sub(after_decimal.into()).wrapping_sub(1) as i16;
+    let weight = digits.len().wrapping_sub(after_decimal).wrapping_sub(1) as i16;
 
     while let Some(&0) = digits.last() {
       let _ = digits.pop();

--- a/wtx/src/http2/process_receipt_frame_ty.rs
+++ b/wtx/src/http2/process_receipt_frame_ty.rs
@@ -130,7 +130,7 @@ where
     ish: &mut InitialServerHeader,
     sorp: &mut Sorp,
   ) -> crate::Result<()> {
-    if self.fi.stream_id <= *self.last_stream_id || self.fi.stream_id.u32() % 2 == 0 {
+    if self.fi.stream_id <= *self.last_stream_id || self.fi.stream_id.u32().is_multiple_of(2) {
       return Err(protocol_err(Http2Error::UnexpectedStreamId));
     }
     if *self.recv_streams_num >= self.hp.max_recv_streams_num() {

--- a/wtx/src/http2/settings_frame.rs
+++ b/wtx/src/http2/settings_frame.rs
@@ -141,7 +141,7 @@ impl SettingsFrame {
       return Ok(settings_frame);
     }
 
-    if bytes.len() % 6 != 0 {
+    if !bytes.len().is_multiple_of(6) {
       return Err(crate::Error::Http2ErrorGoAway(
         Http2ErrorCode::FrameSizeError,
         Http2Error::InvalidSettingsFrameLength,


### PR DESCRIPTION
Unlike the standard `Extend` trait, `TryExtend` can report failures during the extension process.