### PR TITLE
Add `#[clippy::has_significant_drop]` for `MutexGuard`

### DIFF
--- a/wtx/src/de/encode.rs
+++ b/wtx/src/de/encode.rs
@@ -53,6 +53,26 @@ where
   }
 }
 
+impl<DEC, T> Encode<DEC> for &mut T
+where
+  DEC: DEController,
+  T: Encode<DEC>,
+{
+  #[inline]
+  fn encode(
+    &self,
+    aux: &mut DEC::Aux,
+    ew: &mut DEC::EncodeWrapper<'_, '_>,
+  ) -> Result<(), DEC::Error> {
+    (**self).encode(aux, ew)
+  }
+
+  #[inline]
+  fn is_null(&self) -> bool {
+    (**self).is_null()
+  }
+}
+
 impl<DEC, L, R> Encode<DEC> for Either<L, R>
 where
   DEC: DEController,

--- a/wtx/src/misc/mem.rs
+++ b/wtx/src/misc/mem.rs
@@ -5,7 +5,7 @@
 /// - `addr` must point to `len` bytes of valid memory
 #[inline]
 pub unsafe fn mlock(_addr: *mut u8, _len: usize) -> crate::Result<()> {
-  #[cfg(all(feature = "libc", target_os = "linux"))]
+  #[cfg(feature = "libc")]
   {
     // SAFETY: up to the caller
     let mlock = unsafe { libc::mlock(_addr.cast(), _len) };
@@ -14,7 +14,7 @@ pub unsafe fn mlock(_addr: *mut u8, _len: usize) -> crate::Result<()> {
     }
     Ok(())
   }
-  #[cfg(not(all(feature = "libc", target_os = "linux")))]
+  #[cfg(not(feature = "libc"))]
   return Err(crate::Error::UnsupportedMlockPlatform);
 }
 
@@ -25,7 +25,7 @@ pub unsafe fn mlock(_addr: *mut u8, _len: usize) -> crate::Result<()> {
 /// - `addr` must point to `len` bytes of valid memory
 #[inline]
 pub unsafe fn munlock(_addr: *mut u8, _len: usize) -> crate::Result<()> {
-  #[cfg(all(feature = "libc", target_os = "linux"))]
+  #[cfg(feature = "libc")]
   {
     // SAFETY: up to the caller
     let munlock = unsafe { libc::munlock(_addr.cast(), _len) };
@@ -34,11 +34,11 @@ pub unsafe fn munlock(_addr: *mut u8, _len: usize) -> crate::Result<()> {
     }
     Ok(())
   }
-  #[cfg(not(all(feature = "libc", target_os = "linux")))]
+  #[cfg(not(feature = "libc"))]
   return Err(crate::Error::UnsupportedMlockPlatform);
 }
 
-#[cfg(all(feature = "libc", target_os = "linux", test))]
+#[cfg(all(feature = "libc", test))]
 mod tests {
   use crate::{
     collection::Vector,

--- a/wtx/src/sync/mutex.rs
+++ b/wtx/src/sync/mutex.rs
@@ -81,6 +81,7 @@ unsafe impl<T: Send + Sync> Sync for Mutex<T> {}
 
 /// An RAII guard returned by the `lock` and `try_lock` methods. When this structure is dropped
 /// (falls out of scope), the lock will be unlocked.
+#[clippy::has_significant_drop]
 pub struct MutexGuard<'any, T> {
   mutex: &'any Mutex<T>,
 }


### PR DESCRIPTION
Useful for Clippy lints