### PR TITLE
Add `trunc_to_ms` method

### DIFF
--- a/wtx/src/calendar/date_time/tests.rs
+++ b/wtx/src/calendar/date_time/tests.rs
@@ -108,7 +108,7 @@ fn from_timestamp_secs() {
   for (timestamp, str) in elements {
     let instance = DateTime::from_timestamp_secs(timestamp).unwrap();
     assert_eq!(instance.iso_8601().as_str(), str);
-    assert_eq!(instance.timestamp().0, timestamp);
+    assert_eq!(instance.timestamp_secs_and_ns().0, timestamp);
   }
 }
 
@@ -155,16 +155,16 @@ fn iso_8601() {
 
 #[test]
 fn timestamp() {
-  assert_eq!(DateTime::MIN.timestamp().0, -1096193779200);
-  assert_eq!(DateTime::MAX.timestamp().0, 971859427199);
-  assert_eq!(_2025_04_20_14_20_30_1234().timestamp().0, 1745158830);
+  assert_eq!(DateTime::MIN.timestamp_secs_and_ns().0, -1096193779200);
+  assert_eq!(DateTime::MAX.timestamp_secs_and_ns().0, 971859427199);
+  assert_eq!(_2025_04_20_14_20_30_1234().timestamp_secs_and_ns().0, 1745158830);
 }
 
 #[test]
 fn times_zones() {
-  assert_eq!(DateTime::MIN.timestamp().0, -1096193779200);
-  assert_eq!(DateTime::MAX.timestamp().0, 971859427199);
-  assert_eq!(_2025_04_20_14_20_30_1234().timestamp().0, 1745158830);
+  assert_eq!(DateTime::MIN.timestamp_secs_and_ns().0, -1096193779200);
+  assert_eq!(DateTime::MAX.timestamp_secs_and_ns().0, 971859427199);
+  assert_eq!(_2025_04_20_14_20_30_1234().timestamp_secs_and_ns().0, 1745158830);
 }
 
 #[test]

--- a/wtx/src/calendar/time.rs
+++ b/wtx/src/calendar/time.rs
@@ -204,6 +204,15 @@ impl Time {
     Ok(this)
   }
 
+  /// Returns a new instance with the number of nanoseconds truncated to milliseconds.
+  #[inline]
+  #[must_use]
+  pub const fn trunc_to_ms(self) -> Self {
+    let mut new = self;
+    new.nanosecond = new.nanosecond.to_ms().to_ns();
+    new
+  }
+
   /// Returns a new instance with the number of nanoseconds totally erased.
   #[inline]
   #[must_use]

--- a/wtx/src/database/client/postgres/tys/calendar.rs
+++ b/wtx/src/database/client/postgres/tys/calendar.rs
@@ -49,7 +49,7 @@ where
   #[inline]
   fn decode(aux: &mut (), dw: &mut DecodeWrapper<'_>) -> Result<Self, E> {
     let micros: i64 = Decode::<Postgres<E>>::decode(aux, dw)?;
-    let (epoch_ts, _) = PG_EPOCH.timestamp();
+    let (epoch_ts, _) = PG_EPOCH.timestamp_secs_and_ns();
     let this_ts = micros.div_euclid(1_000_000);
     let this_ns = ((micros.rem_euclid(1_000_000)) as u32).wrapping_mul(1_000);
     let ts_diff = epoch_ts.wrapping_add(this_ts);
@@ -68,12 +68,12 @@ where
     if self < &PG_MIN || self > &DateTime::MAX {
       return Err(E::from(PostgresError::TimeStructureOverflow.into()));
     }
-    let (this_ts, this_ns) = self.timestamp();
+    let (this_ts, this_ns) = self.timestamp_secs_and_ns();
     if !this_ns.num().is_multiple_of(1_000) {
       return Err(E::from(PostgresError::TimeStructureWithGreaterPrecision.into()));
     }
     let this_us = this_ns.num() / 1_000;
-    let (epoch_ts, _) = PG_EPOCH.timestamp();
+    let (epoch_ts, _) = PG_EPOCH.timestamp_secs_and_ns();
     let ts_diff = this_ts.wrapping_sub(epoch_ts).wrapping_mul(1_000_000);
     let rslt = ts_diff.wrapping_add(this_us.into());
     Encode::<Postgres<E>>::encode(&rslt, &mut (), ew)
@@ -102,7 +102,7 @@ where
   fn decode(aux: &mut (), dw: &mut DecodeWrapper<'_>) -> Result<Self, E> {
     let days: i32 = Decode::<Postgres<E>>::decode(aux, dw)?;
     let days_in_secs = i64::from(SECONDS_PER_DAY).wrapping_mul(days.into());
-    let timestamp = days_in_secs.wrapping_add(PG_EPOCH.timestamp().0);
+    let timestamp = days_in_secs.wrapping_add(PG_EPOCH.timestamp_secs_and_ns().0);
     Ok(DateTime::from_timestamp_secs(timestamp)?.date())
   }
 }
@@ -116,8 +116,8 @@ where
     if self < &PG_MIN.date() || self > &Date::MAX {
       return Err(E::from(DatabaseError::UnexpectedValueFromBytes { expected: "date" }.into()));
     }
-    let this_timestamp = DateTime::new(*self, Time::ZERO, Utc).timestamp().0;
-    let diff = this_timestamp.wrapping_sub(PG_EPOCH.timestamp().0);
+    let this_timestamp = DateTime::new(*self, Time::ZERO, Utc).timestamp_secs_and_ns().0;
+    let diff = this_timestamp.wrapping_sub(PG_EPOCH.timestamp_secs_and_ns().0);
     let days = i32::try_from(diff / i64::from(SECONDS_PER_DAY)).map_err(crate::Error::from)?;
     Encode::<Postgres<E>>::encode(&days, &mut (), ew)
   }


### PR DESCRIPTION
Complements the already existing `trunc_to_sec` and `trunc_to_us`
