### PR TITLE
Make `SensitiveBytes` generic over different containers

### DIFF
--- a/wtx/src/misc/sensitive_bytes.rs
+++ b/wtx/src/misc/sensitive_bytes.rs
@@ -3,21 +3,29 @@ use core::fmt::Debug;
 use crate::misc::memset_slice_volatile;
 
 /// Bytes that are zeroed when dropped. See `Secret` for a more confidential container.
-pub struct SensitiveBytes<'bytes>(
+pub struct SensitiveBytes<B>(
   /// Bytes
-  pub &'bytes mut [u8],
-);
+  pub B,
+)
+where
+  B: AsMut<[u8]>;
 
-impl Drop for SensitiveBytes<'_> {
-  #[inline]
-  fn drop(&mut self) {
-    memset_slice_volatile(self.0, 0);
-  }
-}
-
-impl Debug for SensitiveBytes<'_> {
+impl<B> Debug for SensitiveBytes<B>
+where
+  B: AsMut<[u8]>,
+{
   #[inline]
   fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
     f.debug_tuple("SensitiveBytes").finish()
+  }
+}
+
+impl<B> Drop for SensitiveBytes<B>
+where
+  B: AsMut<[u8]>,
+{
+  #[inline]
+  fn drop(&mut self) {
+    memset_slice_volatile(self.0.as_mut(), 0);
   }
 }


### PR DESCRIPTION
Makes `SensitiveBytes`  more flexible