### PR TITLE
Add smol's stream

### DIFF
--- a/.scripts/internal-tests0.sh
+++ b/.scripts/internal-tests0.sh
@@ -19,6 +19,7 @@ $rt test-with-features wtx 32-tuple-impls
 $rt test-with-features wtx aes-gcm
 $rt test-with-features wtx arbitrary
 $rt test-with-features wtx argon2
+$rt test-with-features wtx async-net
 $rt test-with-features wtx base64
 $rt test-with-features wtx borsh
 $rt test-with-features wtx client-api-framework

--- a/.scripts/internal-tests1.sh
+++ b/.scripts/internal-tests1.sh
@@ -10,6 +10,7 @@ $rt test-with-features wtx executor
 $rt test-with-features wtx fastrand
 $rt test-with-features wtx flate2
 $rt test-with-features wtx foldhash
+$rt test-with-features wtx futures-lite
 $rt test-with-features wtx grpc
 $rt test-with-features wtx grpc-client
 $rt test-with-features wtx grpc-server

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Contributors should understand their code so they can explain why their changes improve the project.
+Contributors should understand their code so they can provide an explanation if requested.
 
 Before submitting a PR, you should probably run `./scripts/internal-tests.sh` and/or `./scripts/intergration-tests.sh` to make sure everything is fine.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,6 +94,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-net"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
+dependencies = [
+ "async-io",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,6 +213,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9ef36a6fcdb072aa548f3da057640ec10859eb4e91ddf526ee648d50c76a949"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -269,6 +335,15 @@ name = "clap_lex"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "const-oid"
@@ -542,6 +617,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -584,6 +690,25 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-sink"
@@ -696,6 +821,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hmac"
 version = "0.13.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -801,6 +932,12 @@ checksum = "840db8cf39d9ec4dd794376f38acc40d0fc65eec2a8f484f7fd375b84602becd"
 dependencies = [
  "zlib-rs",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litrs"
@@ -949,6 +1086,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1009,6 +1152,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkcs1"
 version = "0.8.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1026,6 +1180,20 @@ checksum = "93eac55f10aceed84769df670ea4a32d2ffad7399400d41ee1c13b1cd8e1b478"
 dependencies = [
  "der",
  "spki",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1195,6 +1363,19 @@ name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+
+[[package]]
+name = "rustix"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+dependencies = [
+ "bitflags 2.9.4",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "rustls"
@@ -1811,6 +1992,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1905,6 +2095,7 @@ dependencies = [
  "aes-gcm",
  "arbitrary",
  "argon2",
+ "async-net",
  "base64",
  "borsh",
  "crossbeam-channel",
@@ -1915,6 +2106,7 @@ dependencies = [
  "fastrand",
  "flate2",
  "foldhash",
+ "futures-lite",
  "getrandom 0.3.3",
  "hashbrown",
  "hmac",

--- a/wtx/Cargo.toml
+++ b/wtx/Cargo.toml
@@ -1,5 +1,6 @@
 [dependencies]
 arbitrary = { default-features = false, features = ["derive_arbitrary"], optional = true, version = "1.0" }
+async-net = { default-features = false, optional = true, version = "2.0" }
 base64 = { default-features = false, features = ["alloc"], optional = true, version = "0.22" }
 borsh = { default-features = false, features = ["derive"], optional = true, version = "1.0" }
 crossbeam-channel = { default-features = false, optional = true, version = "0.5" }
@@ -8,6 +9,7 @@ embassy-time = { default-features = false, optional = true, version = "0.3" }
 fastrand = { default-features = false, optional = true, version = "2.0" }
 flate2 = { default-features = false, features = ["zlib-rs"], optional = true, version = "1.0" }
 foldhash = { default-features = false, optional = true, version = "0.2" }
+futures-lite = { default-features = false, optional = true, version = "2.0" }
 getrandom = { default-features = false, optional = true, version = "0.3" }
 hashbrown = { default-features = false, features = ["default-hasher", "inline-more"], optional = true, version = "0.16" }
 httparse = { default-features = false, optional = true, version = "1.0" }
@@ -56,6 +58,7 @@ wtx = { default-features = false, features = ["executor", "macros"], path = "." 
 [features]
 32-tuple-impls = []
 arbitrary = ["dep:arbitrary", "std"]
+async-net = ["dep:async-net", "futures-lite"]
 borsh = ["borsh/std", "std"]
 client-api-framework = []
 crossbeam-channel = ["crossbeam-channel/std", "std"]

--- a/wtx/src/misc/secret.rs
+++ b/wtx/src/misc/secret.rs
@@ -116,7 +116,7 @@ mod static_keys {
     ///
     /// `buffer` is utilized for internal operations and can be freely reused for any other action
     /// afterwards.
-    pub fn peek<B, E, T>(&self, buffer: &mut B, mut fun: impl FnMut(&[u8]) -> T) -> Result<T, E>
+    pub fn peek<B, E, T>(&self, buffer: &mut B, fun: impl FnOnce(&[u8]) -> T) -> Result<T, E>
     where
       for<'any> B: Clear + LeaseMut<[u8]> + TryExtend<&'any [u8], Error = E>,
       E: From<crate::Error>,

--- a/wtx/src/stream.rs
+++ b/wtx/src/stream.rs
@@ -30,6 +30,8 @@ macro_rules! _local_write_all_vectored {
   };
 }
 
+#[cfg(feature = "async-net")]
+mod async_net;
 mod bytes_stream;
 #[cfg(feature = "embassy-net")]
 mod embassy_net;

--- a/wtx/src/stream/async_net.rs
+++ b/wtx/src/stream/async_net.rs
@@ -1,0 +1,24 @@
+use crate::stream::{StreamReader, StreamWriter};
+use async_net::TcpStream;
+use futures_lite::{AsyncReadExt, AsyncWriteExt};
+
+impl StreamReader for TcpStream {
+  #[inline]
+  async fn read(&mut self, bytes: &mut [u8]) -> crate::Result<usize> {
+    Ok(<Self as AsyncReadExt>::read(self, bytes).await?)
+  }
+}
+
+impl StreamWriter for TcpStream {
+  #[inline]
+  async fn write_all(&mut self, bytes: &[u8]) -> crate::Result<()> {
+    <Self as AsyncWriteExt>::write_all(self, bytes).await?;
+    Ok(())
+  }
+
+  #[inline]
+  async fn write_all_vectored(&mut self, bytes: &[&[u8]]) -> crate::Result<()> {
+    _local_write_all_vectored!(bytes, self, |io_slices| self.write_vectored(io_slices).await);
+    Ok(())
+  }
+}


### PR DESCRIPTION
`wtx` now supports `async_net::TcpStream`, `embassy_net::tcp::TcpSocket`, `tokio::net::TcpStream` and `std::net::TcpStream`.