### PR TITLE
Make `execute_ignored` `Send`

### DIFF
--- a/wtx/src/database/executor.rs
+++ b/wtx/src/database/executor.rs
@@ -23,10 +23,15 @@ pub trait Executor {
     &mut self,
     cmd: &str,
   ) -> impl Future<Output = Result<(), <Self::Database as DEController>::Error>> {
-    async {
-      self.execute_many(&mut (), cmd, |_| Ok(())).await?;
-      Ok(())
+    // FIXME(stable): For some reason this method makes `http-server-framework-session` !Send.
+    const fn nothing() -> &'static mut () {
+      static mut NOTHING: &mut () = &mut ();
+      // SAFETY: Does nothing, pointer means nothing and is not actually used or referenced. See
+      // `TryExtend::IS_UNIT`
+      unsafe { NOTHING }
     }
+
+    self.execute_many(nothing(), cmd, |_| Ok(()))
   }
 
   /// Execute - Many

--- a/wtx/src/http/session/session_store.rs
+++ b/wtx/src/http/session/session_store.rs
@@ -190,10 +190,7 @@ mod postgres {
 
     #[inline]
     async fn delete_expired(&mut self) -> Result<(), E> {
-      // FIXME(stable): the use of `execute_ignored` makes `http-server-framework-session` !Send.
-      self
-        .execute_many(&mut (), "DELETE FROM session WHERE expires_at <= NOW()", |_| Ok(()))
-        .await?;
+      self.execute_ignored("DELETE FROM session WHERE expires_at <= NOW()").await?;
       Ok(())
     }
 


### PR DESCRIPTION
For some reason `execute_ignored` makes `http-server-framework-session` !Send.