### PR TITLE
Remove hard-coded `crate::Error`

### DIFF
--- a/wtx-ui/src/schema_manager.rs
+++ b/wtx-ui/src/schema_manager.rs
@@ -28,7 +28,7 @@ pub(crate) async fn schema_manager(sm: SchemaManager) -> wtx::Result<()> {
   match uri.scheme() {
     "postgres" | "postgresql" => {
       let mut rng = ChaCha20::from_os()?;
-      let executor = PostgresExecutor::connect(
+      let executor = PostgresExecutor::<wtx::Error, _, _>::connect(
         &Config::from_uri(&uri)?,
         ExecutorBuffer::new(usize::MAX, &mut rng),
         &mut rng,

--- a/wtx/src/database/schema_manager/commands.rs
+++ b/wtx/src/database/schema_manager/commands.rs
@@ -15,6 +15,7 @@ use crate::{
     executor::Executor,
     schema_manager::{DEFAULT_BATCH_SIZE, SchemaManagement, UserMigration},
   },
+  de::DEController,
   misc::Lease,
 };
 use alloc::string::String;
@@ -76,7 +77,9 @@ where
   E: SchemaManagement,
 {
   /// Retrieves all inserted elements.
-  pub async fn all_elements(&mut self) -> crate::Result<Vector<Identifier>> {
+  pub async fn all_elements(
+    &mut self,
+  ) -> Result<Vector<Identifier>, <E::Database as DEController>::Error> {
     let mut buffer = Vector::new();
     self.executor.all_elements((&mut String::new(), &mut buffer)).await?;
     Ok(buffer)

--- a/wtx/src/database/schema_manager/commands/clear.rs
+++ b/wtx/src/database/schema_manager/commands/clear.rs
@@ -1,6 +1,7 @@
 use crate::{
   collection::Vector,
   database::schema_manager::{Commands, SchemaManagement},
+  de::DEController,
 };
 use alloc::string::String;
 
@@ -10,7 +11,7 @@ where
 {
   /// Tries to clear all objects of a database, including separated namespaces/schemas.
   #[inline]
-  pub async fn clear(&mut self) -> crate::Result<()> {
+  pub async fn clear(&mut self) -> Result<(), <E::Database as DEController>::Error> {
     self.executor.clear((&mut String::new(), &mut Vector::new())).await
   }
 }

--- a/wtx/src/database/schema_manager/commands/validate.rs
+++ b/wtx/src/database/schema_manager/commands/validate.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "std")]
+use crate::de::DEController;
 use crate::{
   collection::Vector,
   database::{
@@ -27,7 +29,7 @@ where
     &mut self,
     mg: &UserMigrationGroup<S>,
     migrations: I,
-  ) -> crate::Result<()>
+  ) -> Result<(), <E::Database as DEController>::Error>
   where
     DBS: Lease<[DatabaseTy]> + 'migration,
     I: Clone + Iterator<Item = &'migration UserMigration<DBS, S>>,
@@ -43,7 +45,10 @@ where
   /// Applies `validate` to a set of groups according to the configuration file
   #[inline]
   #[cfg(feature = "std")]
-  pub async fn validate_from_toml(&mut self, path: &Path) -> crate::Result<()> {
+  pub async fn validate_from_toml(
+    &mut self,
+    path: &Path,
+  ) -> Result<(), <E::Database as DEController>::Error> {
     let (mut migration_groups, _) = parse_root_toml(path)?;
     migration_groups.sort_unstable();
     for mg in migration_groups.into_iter() {
@@ -55,7 +60,10 @@ where
   /// Applies `validate` to a set of migrations according to a given directory
   #[inline]
   #[cfg(feature = "std")]
-  pub async fn validate_from_dir(&mut self, path: &Path) -> crate::Result<()> {
+  pub async fn validate_from_dir(
+    &mut self,
+    path: &Path,
+  ) -> Result<(), <E::Database as DEController>::Error> {
     self.do_validate_from_dir((&mut String::new(), &mut Vector::new()), path).await
   }
 
@@ -97,7 +105,7 @@ where
     &mut self,
     (buffer_cmd, buffer_db_migrations): (&mut String, &mut Vector<DbMigration>),
     path: &Path,
-  ) -> crate::Result<()> {
+  ) -> Result<(), <E::Database as DEController>::Error> {
     let opt = group_and_migrations_from_path(path, Ord::cmp);
     let Ok((mg, mut migrations)) = opt else { return Ok(()) };
     self.executor.migrations(buffer_cmd, &mg, buffer_db_migrations).await?;

--- a/wtx/src/database/schema_manager/fixed_sql_commands/mysql.rs
+++ b/wtx/src/database/schema_manager/fixed_sql_commands/mysql.rs
@@ -15,9 +15,10 @@ pub(crate) const CREATE_MIGRATION_TABLES: &str = concat!(
 );
 
 // https://stackoverflow.com/questions/12403662/how-to-remove-all-mysql-tables-from-the-command-line-without-drop-database-permi/18625545#18625545
-pub(crate) async fn clear<E>(executor: &mut E) -> crate::Result<()>
+pub(crate) async fn clear<E, ERR>(executor: &mut E) -> Result<(), ERR>
 where
-  E: Executor<Database = Mysql<crate::Error>>,
+  E: Executor<Database = Mysql<ERR>>,
+  ERR: From<crate::Error>,
 {
   let cmd = "
     SET FOREIGN_KEY_CHECKS = 0;
@@ -39,12 +40,13 @@ where
 }
 
 // https://github.com/flyway/flyway/blob/master/flyway-core/src/main/java/org/flywaydb/core/internal/database/mysql/MySQLSchema.java
-pub(crate) async fn table_names<E>(
+pub(crate) async fn table_names<E, ERR>(
   executor: &mut E,
   results: &mut Vector<Identifier>,
-) -> crate::Result<()>
+) -> Result<(), ERR>
 where
-  E: Executor<Database = Mysql<crate::Error>>,
+  E: Executor<Database = Mysql<ERR>>,
+  ERR: From<crate::Error>,
 {
   let cmd = "SELECT
       all_tables.table_name AS table_name

--- a/wtx/src/database/schema_manager/integration_tests/backend.rs
+++ b/wtx/src/database/schema_manager/integration_tests/backend.rs
@@ -2,7 +2,7 @@ use crate::{
   calendar::{Duration, Instant},
   collection::Vector,
   database::{
-    Identifier,
+    Database, Identifier,
     schema_manager::{
       Commands, DbMigration, SchemaManagement,
       integration_tests::{_migrate_doc_test, AuxTestParams},
@@ -11,7 +11,7 @@ use crate::{
 };
 use alloc::string::String;
 
-pub(crate) async fn _backend_has_migration_with_utc_time<E>(
+pub(crate) async fn _backend_has_migration_with_utc_time<DB, E>(
   (buffer_cmd, buffer_db_migrations, _): (
     &mut String,
     &mut Vector<DbMigration>,
@@ -20,7 +20,8 @@ pub(crate) async fn _backend_has_migration_with_utc_time<E>(
   c: &mut Commands<E>,
   _: AuxTestParams,
 ) where
-  E: SchemaManagement,
+  DB: Database<Error = crate::Error>,
+  E: SchemaManagement<Database = DB>,
 {
   let mg = _migrate_doc_test(c).await;
   c.executor_mut().migrations(buffer_cmd, &mg, buffer_db_migrations).await.unwrap();

--- a/wtx/src/database/schema_manager/integration_tests/schema.rs
+++ b/wtx/src/database/schema_manager/integration_tests/schema.rs
@@ -3,20 +3,24 @@ pub(crate) mod without_schema;
 
 use crate::{
   collection::Vector,
-  database::schema_manager::{
-    Commands, SchemaManagement, UserMigrationGroup, integration_tests::AuxTestParams,
+  database::{
+    Database,
+    schema_manager::{
+      Commands, SchemaManagement, UserMigrationGroup, integration_tests::AuxTestParams,
+    },
   },
 };
 use alloc::string::String;
 use std::path::Path;
 
-pub(crate) async fn migrate_works<E>(
+pub(crate) async fn migrate_works<DB, E>(
   buffer_cmd: &mut String,
   c: &mut Commands<E>,
   aux: AuxTestParams,
   wtx_schema_tables: usize,
 ) where
-  E: SchemaManagement,
+  DB: Database<Error = crate::Error>,
+  E: SchemaManagement<Database = DB>,
 {
   let path = Path::new("../.test-utils/migrations.toml");
   let mut db_migrations = Vector::new();

--- a/wtx/src/database/schema_manager/integration_tests/schema/with_schema.rs
+++ b/wtx/src/database/schema_manager/integration_tests/schema/with_schema.rs
@@ -1,7 +1,7 @@
 use crate::{
   collection::Vector,
   database::{
-    Identifier,
+    Database, Identifier,
     schema_manager::{
       self, Commands, DbMigration, MigrationStatus, SchemaManagement,
       integration_tests::{_migrate_doc_test, AuxTestParams},
@@ -10,7 +10,7 @@ use crate::{
 };
 use alloc::string::String;
 
-pub(crate) async fn all_tables_returns_the_number_of_tables_of_wtx_schema<E>(
+pub(crate) async fn all_tables_returns_the_number_of_tables_of_wtx_schema<DB, E>(
   (buffer_cmd, _, buffer_idents, _): (
     &mut String,
     &mut Vector<DbMigration>,
@@ -20,7 +20,8 @@ pub(crate) async fn all_tables_returns_the_number_of_tables_of_wtx_schema<E>(
   c: &mut Commands<E>,
   _: AuxTestParams,
 ) where
-  E: SchemaManagement,
+  DB: Database<Error = crate::Error>,
+  E: SchemaManagement<Database = DB>,
 {
   c.executor_mut().table_names(buffer_cmd, buffer_idents, "_wtx").await.unwrap();
   assert_eq!(buffer_idents.len(), 0);
@@ -31,7 +32,7 @@ pub(crate) async fn all_tables_returns_the_number_of_tables_of_wtx_schema<E>(
   buffer_idents.clear();
 }
 
-pub(crate) async fn migrate_works<E>(
+pub(crate) async fn migrate_works<DB, E>(
   (buffer_cmd, _, _, _): (
     &mut String,
     &mut Vector<DbMigration>,
@@ -41,7 +42,8 @@ pub(crate) async fn migrate_works<E>(
   c: &mut Commands<E>,
   aux: AuxTestParams,
 ) where
-  E: SchemaManagement,
+  DB: Database<Error = crate::Error>,
+  E: SchemaManagement<Database = DB>,
 {
   schema_manager::integration_tests::schema::migrate_works(buffer_cmd, c, aux, 2).await
 }

--- a/wtx/src/database/schema_manager/integration_tests/schema/without_schema.rs
+++ b/wtx/src/database/schema_manager/integration_tests/schema/without_schema.rs
@@ -1,7 +1,7 @@
 use crate::{
   collection::Vector,
   database::{
-    Identifier,
+    Database, Identifier,
     schema_manager::{
       Commands, DbMigration, MigrationStatus, SchemaManagement, integration_tests::AuxTestParams,
     },
@@ -9,7 +9,7 @@ use crate::{
 };
 use alloc::string::String;
 
-pub(crate) async fn _migrate_works<E>(
+pub(crate) async fn _migrate_works<DB, E>(
   (buffer_cmd, _, _, _): (
     &mut String,
     &mut Vector<DbMigration>,
@@ -19,7 +19,8 @@ pub(crate) async fn _migrate_works<E>(
   c: &mut Commands<E>,
   aux: AuxTestParams,
 ) where
-  E: SchemaManagement,
+  DB: Database<Error = crate::Error>,
+  E: SchemaManagement<Database = DB>,
 {
   crate::database::schema_manager::integration_tests::schema::migrate_works(buffer_cmd, c, aux, 6)
     .await


### PR DESCRIPTION
Schema managers should be generic over different errors