### PR TITLE
Fix gRPC middleware

### DIFF
--- a/wtx/src/grpc/grpc_middleware.rs
+++ b/wtx/src/grpc/grpc_middleware.rs
@@ -25,7 +25,18 @@ where
     &self,
     _: &mut CA,
     _: &mut Self::Aux,
-    req: &mut Request<ReqResBuffer>,
+    _: &mut Request<ReqResBuffer>,
+    _: &mut GrpcManager<DRSR>,
+  ) -> Result<ControlFlow<StatusCode, ()>, E> {
+    Ok(ControlFlow::Continue(()))
+  }
+
+  #[inline]
+  async fn res(
+    &self,
+    _: &mut CA,
+    _: &mut Self::Aux,
+    req: Response<&mut ReqResBuffer>,
     stream_aux: &mut GrpcManager<DRSR>,
   ) -> Result<ControlFlow<StatusCode, ()>, E> {
     req.rrd.headers.push_from_iter_many([
@@ -35,17 +46,6 @@ where
       ),
       Header::new(false, true, "grpc-status", [stream_aux.status_code_mut().as_str()].into_iter()),
     ])?;
-    Ok(ControlFlow::Continue(()))
-  }
-
-  #[inline]
-  async fn res(
-    &self,
-    _: &mut CA,
-    _: &mut Self::Aux,
-    _: Response<&mut ReqResBuffer>,
-    _: &mut GrpcManager<DRSR>,
-  ) -> Result<ControlFlow<StatusCode, ()>, E> {
     Ok(ControlFlow::Continue(()))
   }
 }

--- a/wtx/src/http/headers.rs
+++ b/wtx/src/http/headers.rs
@@ -462,13 +462,18 @@ struct HeaderParts {
 
 #[cfg(test)]
 mod tests {
-  use crate::http::{Header, Headers, Trailers};
+  use crate::http::{Header, Headers, KnownHeaderName, Trailers};
 
   #[test]
   fn pop_resets_trailer_tail_state_correctly() {
     let mut headers = Headers::new();
 
-    headers.push_from_iter(Header::from_name_and_value("Content-Type", ["text/plain"])).unwrap();
+    headers
+      .push_from_iter(Header::from_name_and_value(
+        KnownHeaderName::ContentType.into(),
+        ["text/plain"],
+      ))
+      .unwrap();
     assert_eq!(headers.bytes_len(), 22);
     assert_eq!(headers.headers_len(), 1);
     assert_eq!(headers.trailers(), Trailers::None);
@@ -485,7 +490,7 @@ mod tests {
     assert_eq!(headers.trailers(), Trailers::None);
 
     let first = headers.get_by_idx(0).unwrap();
-    assert_eq!(first.name, "Content-Type");
+    assert_eq!(first.name, <&str>::from(KnownHeaderName::ContentType));
     assert!(!first.is_trailer);
   }
 }


### PR DESCRIPTION
gRPC headers are meant to be inserted in responses