### PR TITLE
fix: Fix PgSQL types

### DIFF
--- a/wtx/src/crypto/signature/signature_ty.rs
+++ b/wtx/src/crypto/signature/signature_ty.rs
@@ -107,12 +107,12 @@ where
 {
   #[inline]
   fn runtime_ty(&self) -> Option<D::Ty> {
-    <&str as Typed<D>>::runtime_ty(&<&str>::from(*self))
+    None
   }
 
   #[inline]
   fn static_ty() -> Option<D::Ty> {
-    <&str as Typed<D>>::static_ty()
+    None
   }
 }
 

--- a/wtx/src/database/client/postgres/macros.rs
+++ b/wtx/src/database/client/postgres/macros.rs
@@ -13,7 +13,7 @@ macro_rules! impl_primitive {
           $({
             let signed = $ty1::from_be_bytes(array);
             num = signed.try_into().map_err(crate::Error::from)?;
-          })*
+          })?
           return Ok(num);
         }
         Err(E::from(DatabaseError::UnexpectedBufferSize {

--- a/wtx/src/database/client/postgres/macros.rs
+++ b/wtx/src/database/client/postgres/macros.rs
@@ -1,22 +1,29 @@
 macro_rules! impl_primitive {
-  ($instance:expr, [$($elem:ident),+], $ty:ident, $pg_ty:expr) => {
-    impl<E> Decode<'_, Postgres<E>> for $ty
+  ($instance:expr, [$($elem:ident),+], $pg_ty:expr, $ty0:ident $(, $ty1:ident)?) => {
+    impl<E> Decode<'_, Postgres<E>> for $ty0
     where
       E: From<crate::Error>,
     {
       #[inline]
       fn decode(dw: &mut DecodeWrapper<'_, '_>) -> Result<Self, E> {
         if let &[$($elem,)+] = dw.bytes() {
-          return Ok(<Self>::from_be_bytes([$($elem),+]).into());
+          let array = [$($elem),+];
+          #[allow(unused_assignments, unused_mut, reason = "depends on macro")]
+          let mut num = <Self>::from_be_bytes(array);
+          $({
+            let signed = $ty1::from_be_bytes(array);
+            num = signed.try_into().map_err(crate::Error::from)?;
+          })*
+          return Ok(num);
         }
         Err(E::from(DatabaseError::UnexpectedBufferSize {
-          expected: Usize::from(size_of::<$ty>()).into_u64().try_into().unwrap_or(u32::MAX),
+          expected: Usize::from(size_of::<$ty0>()).into_u64().try_into().unwrap_or(u32::MAX),
           received: Usize::from(dw.bytes().len()).into_u64().try_into().unwrap_or(u32::MAX)
         }.into()))
       }
     }
 
-    impl<E> Encode<Postgres<E>> for $ty
+    impl<E> Encode<Postgres<E>> for $ty0
     where
       E: From<crate::Error>,
     {
@@ -27,7 +34,7 @@ macro_rules! impl_primitive {
       }
     }
 
-    impl<E> Typed<Postgres<E>> for $ty
+    impl<E> Typed<Postgres<E>> for $ty0
     where
       E: From<crate::Error>
     {
@@ -42,7 +49,7 @@ macro_rules! impl_primitive {
       }
     }
 
-    test!($ty, $ty, $instance);
+    test!($ty0, $ty0, $instance);
   }
 }
 

--- a/wtx/src/database/client/postgres/tys/collection.rs
+++ b/wtx/src/database/client/postgres/tys/collection.rs
@@ -41,7 +41,7 @@ where
 
   #[inline]
   fn static_ty() -> Option<Ty> {
-    Some(Ty::ByteaArray)
+    Some(Ty::Bytea)
   }
 }
 test!(bytes, &[u8], &[1u8, 2, 3, 4]);
@@ -64,12 +64,12 @@ where
 {
   #[inline]
   fn runtime_ty(&self) -> Option<Ty> {
-    Some(Ty::ByteaArray)
+    Some(Ty::Bytea)
   }
 
   #[inline]
   fn static_ty() -> Option<Ty> {
-    Some(Ty::ByteaArray)
+    Some(Ty::Bytea)
   }
 }
 

--- a/wtx/src/database/client/postgres/tys/primitives.rs
+++ b/wtx/src/database/client/postgres/tys/primitives.rs
@@ -55,15 +55,15 @@ where
 kani!(bool_true, bool);
 kani!(bool_false, bool);
 
-impl_primitive!(37.0, [a, b, c, d], f32, Ty::Float4);
-impl_primitive!(37.0, [a, b, c, d, e, f, g, h], f64, Ty::Float8);
+impl_primitive!(37.0, [a, b, c, d], Ty::Float4, f32);
+impl_primitive!(37.0, [a, b, c, d, e, f, g, h], Ty::Float8, f64);
 
-impl_primitive!(37, [a], i8, Ty::Char);
-impl_primitive!(37, [a, b], i16, Ty::Int2);
-impl_primitive!(37, [a, b, c, d], i32, Ty::Int4);
-impl_primitive!(37, [a, b, c, d, e, f, g, h], i64, Ty::Int8);
+impl_primitive!(37, [a], Ty::Char, i8);
+impl_primitive!(37, [a, b], Ty::Int2, i16);
+impl_primitive!(37, [a, b, c, d], Ty::Int4, i32);
+impl_primitive!(37, [a, b, c, d, e, f, g, h], Ty::Int8, i64);
 
-impl_primitive!(37, [a], u8, Ty::Bytea);
-impl_primitive!(37, [a, b], u16, Ty::ByteaArray);
-impl_primitive!(37, [a, b, c, d], u32, Ty::ByteaArray);
-impl_primitive!(37, [a, b, c, d, e, f, g, h], u64, Ty::ByteaArray);
+impl_primitive!(37, [a], Ty::Bytea, u8, i8);
+impl_primitive!(37, [a, b], Ty::Int2, u16, i16);
+impl_primitive!(37, [a, b, c, d], Ty::Int4, u32, i32);
+impl_primitive!(37, [a, b, c, d, e, f, g, h], Ty::Int8, u64, i64);

--- a/wtx/src/database/database_error.rs
+++ b/wtx/src/database/database_error.rs
@@ -8,7 +8,7 @@ pub enum DatabaseError {
   /// The method `expand` of `StatementBuilder` must be called only once.
   InconsistentStatementBuilder,
   /// A "null" field received from the database was decoded as a non-nullable type or value.
-  MissingFieldDataInDecoding(ShortStrU8<'static>, Option<u16>),
+  MissingFieldDataInDecoding(ShortStrU8<'static>, Option<u8>),
   /// Expected one record but got none.
   MissingSingleRecord,
   /// Received size differs from expected size.

--- a/wtx/src/database/record.rs
+++ b/wtx/src/database/record.rs
@@ -19,7 +19,7 @@ pub trait Record<'exec>: Sized {
     let mut dw = self.value(ci).ok_or_else(|| {
       DatabaseError::MissingFieldDataInDecoding(
         type_name::<D>().into(),
-        ci.idx(self).map(|el| u16::try_from(el).unwrap_or(u16::MAX)),
+        ci.idx(self).map(|el| u8::try_from(el).unwrap_or(u8::MAX)),
       )
       .into()
     })?;

--- a/wtx/src/error.rs
+++ b/wtx/src/error.rs
@@ -249,7 +249,7 @@ pub enum Error {
   CryptoError(crate::crypto::CryptoError),
   #[cfg(feature = "database")]
   #[doc = associated_element_doc!()]
-  DatabaseError(Box<crate::database::DatabaseError>),
+  DatabaseError(crate::database::DatabaseError),
   #[doc = associated_element_doc!()]
   FixedStringError(FixedStringError),
   #[doc = associated_element_doc!()]
@@ -621,7 +621,7 @@ impl From<crate::codec::CodecError> for Error {
 impl From<crate::database::DatabaseError> for Error {
   #[inline]
   fn from(from: crate::database::DatabaseError) -> Self {
-    Self::DatabaseError(from.into())
+    Self::DatabaseError(from)
   }
 }
 

--- a/wtx/src/misc/sensitive_bytes.rs
+++ b/wtx/src/misc/sensitive_bytes.rs
@@ -112,11 +112,11 @@ mod database {
     DB: Database,
   {
     fn runtime_ty(&self) -> Option<DB::Ty> {
-      self.bytes.runtime_ty()
+      None
     }
 
     fn static_ty() -> Option<DB::Ty> {
-      B::static_ty()
+      None
     }
   }
 }


### PR DESCRIPTION
Unsigned integers weren't checked to see if they didn't extrapolate their associated signed limits.