### PR TITLE
fix: byte arrays in pgsql

### DIFF
--- a/wtx/src/database/client/postgres/integration_tests.rs
+++ b/wtx/src/database/client/postgres/integration_tests.rs
@@ -93,6 +93,24 @@ fn batch() {
 }
 
 #[test]
+fn bytes() {
+  Runtime::new().block_on(async {
+    let id = 1;
+    let bytes = &[255, 2, 3];
+    let mut executor = executor().await;
+    executor.execute_none("DROP TABLE IF EXISTS bytes_test").await.unwrap();
+    executor.execute_none("CREATE TABLE bytes_test(id INT, foo BYTEA[])").await.unwrap();
+    executor.execute_stmt_none("INSERT INTO bytes_test VALUES($1, $2)", (id, bytes)).await.unwrap();
+    let record = executor
+      .execute_stmt_single("SELECT id,foo FROM bytes_test WHERE foo = $1", (bytes,))
+      .await
+      .unwrap();
+    assert_eq!(record.decode::<_, i32>(0).unwrap(), 1);
+    assert_eq!(record.decode::<_, [u8; 3]>(1).unwrap(), *bytes);
+  });
+}
+
+#[test]
 fn custom_composite_type() {
   Runtime::new()
     .block_on(async {

--- a/wtx/src/database/client/postgres/tys/primitives.rs
+++ b/wtx/src/database/client/postgres/tys/primitives.rs
@@ -63,7 +63,9 @@ impl_primitive!(37, [a, b], Ty::Int2, i16);
 impl_primitive!(37, [a, b, c, d], Ty::Int4, i32);
 impl_primitive!(37, [a, b, c, d, e, f, g, h], Ty::Int8, i64);
 
-impl_primitive!(37, [a], Ty::Bytea, u8, i8);
+// A hack, more or less. `Ty::Char` is not used because of arrays. For example, `[u8; 3]` would
+// imply `CHAR[]`
+impl_primitive!(37, [a], Ty::Bytea, u8);
 impl_primitive!(37, [a, b], Ty::Int2, u16, i16);
 impl_primitive!(37, [a, b, c, d], Ty::Int4, u32, i32);
 impl_primitive!(37, [a, b, c, d, e, f, g, h], Ty::Int8, u64, i64);


### PR DESCRIPTION
A hack, more or less. `Ty::Char` is not used because of arrays. For example, `[u8; 3]` would imply `CHAR[]`